### PR TITLE
Adds "None" theme option to Theme Picker 

### DIFF
--- a/theme-picker-modal.ts
+++ b/theme-picker-modal.ts
@@ -1,6 +1,9 @@
 import { App, FuzzySuggestModal, KeymapEventListener } from "obsidian";
 
 export default class ThemePickerPluginModal extends FuzzySuggestModal<string> {
+	DEFAULT_THEME_KEY = "";
+	DEFAULT_THEME_TEXT = "None";
+
 	initialTheme: string;
 	previewing = false;
 
@@ -51,11 +54,15 @@ export default class ThemePickerPluginModal extends FuzzySuggestModal<string> {
 
 	getItems(): any[] {
 		//@ts-ignore
-		return this.app.customCss.themes;
+		return [this.DEFAULT_THEME_KEY, ...this.app.customCss.themes];
 	}
 
 	getItemText(item: any): string {
-		return item;
+		if (item === this.DEFAULT_THEME_KEY) {
+			return this.DEFAULT_THEME_TEXT;
+		} else {
+			return item;
+		}
 	}
 
 	onChooseItem(item: any, evt: MouseEvent | KeyboardEvent): void {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.0.2-next.1`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Adds "None" theme option to Theme Picker [#3](https://github.com/kenset/obsidian-theme-picker/pull/3) ([@kenset](https://github.com/kenset))
  - Adds Dark Mode Toggle Icon in Status Bar [#2](https://github.com/kenset/obsidian-theme-picker/pull/2) ([@kenset](https://github.com/kenset))
  - CI Updates [#7](https://github.com/kenset/obsidian-theme-picker/pull/7) ([@kenset](https://github.com/kenset))
  - Update main.yml [#6](https://github.com/kenset/obsidian-theme-picker/pull/6) ([@kenset](https://github.com/kenset))
  - Adds author [#5](https://github.com/kenset/obsidian-theme-picker/pull/5) ([@kenset](https://github.com/kenset))
  - CI [#4](https://github.com/kenset/obsidian-theme-picker/pull/4) ([@kenset](https://github.com/kenset))
  
  #### Authors: 2
  
  - [@kenset](https://github.com/kenset)
  - kenset ([@kenset](https://github.com/kenset))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
